### PR TITLE
Fix ods2cascade argument order in usage guide

### DIFF
--- a/doc/manual/source/using.rst
+++ b/doc/manual/source/using.rst
@@ -43,7 +43,7 @@ locations, we can invoke :program:`ods2cascade` like so:
 
   .. code-block:: bash
 
-     $ ods2cascade /etc/opendnssec/conf.xml /etc/cascade/config.toml /tmp/out
+     $ ods2cascade /etc/cascade/config.toml /etc/opendnssec/conf.xml /tmp/out
 
 This will:
 


### PR DESCRIPTION
## Summary
Corrects the getting-started command so the Cascade TOML path appears before the OpenDNSSEC XML path, matching the CLI usage and the documented output.

## Validation
- compared the example against `src/main.rs` CLI usage
- `git diff --check`

`cargo test --locked` was not run because Cargo is unavailable in the local environment; this is a one-line documentation-only change.

Fixes #60