### PR TITLE
docs: fix ods2cascade argument order in using guide

### DIFF
--- a/doc/manual/source/using.rst
+++ b/doc/manual/source/using.rst
@@ -43,7 +43,7 @@ locations, we can invoke :program:`ods2cascade` like so:
 
   .. code-block:: bash
 
-     $ ods2cascade /etc/opendnssec/conf.xml /etc/cascade/config.toml /tmp/out
+     $ ods2cascade /etc/cascade/config.toml /etc/opendnssec/conf.xml /tmp/out
 
 This will:
 


### PR DESCRIPTION
## What & why

Corrects the example command in the using guide. The CLI expects the Cascade TOML path before the OpenDNSSEC XML path; the manual had them reversed, which produced the `TOML parse error` shown in the issue.

Closes #60.

## Verification

- Confirmed against `src/main.rs`: the usage line and argument mapping are `<path/to/cascade.toml> <path/to/opendnssec/conf.xml> <path/to/write/files/to>`.
- Docs-only change.
