### PR TITLE
Fix argument order in ods2cascade usage example (issue #60)

### DIFF
--- a/doc/manual/source/using.rst
+++ b/doc/manual/source/using.rst
@@ -43,7 +43,7 @@ locations, we can invoke :program:`ods2cascade` like so:
 
   .. code-block:: bash
 
-     $ ods2cascade /etc/opendnssec/conf.xml /etc/cascade/config.toml /tmp/out
+     $ ods2cascade /etc/cascade/config.toml /etc/opendnssec/conf.xml /tmp/out
 
 This will:
 


### PR DESCRIPTION
The documentation showed the wrong argument order: XML config before TOML config. The tool expects TOML config first, then XML.