### PR TITLE
Use the new policy file subcrate from Cascade to enable upgrading to latest Cascade.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 [[package]]
 name = "cascade-cfg"
 version = "0.1.0-beta6-dev"
-source = "git+https://github.com/NLnetLabs/cascade?branch=policy-file-subcrate#92ae3fec3cdda8e6830485d8e1d0d03c7ac09019"
+source = "git+https://github.com/NLnetLabs/cascade#3a755b195d2c25bfd481bd78dbc207721cbf38e3"
 dependencies = [
  "camino",
  "clap",
@@ -196,6 +196,7 @@ dependencies = [
 [[package]]
 name = "cascade-policy-file"
 version = "0.1.0-beta6-dev"
+source = "git+https://github.com/NLnetLabs/cascade#3a755b195d2c25bfd481bd78dbc207721cbf38e3"
 dependencies = [
  "camino",
  "domain",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,15 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
-name = "arc-swap"
-version = "1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,68 +92,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "axum"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
-dependencies = [
- "axum-core",
- "bytes",
- "form_urlencoded",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
- "tracing",
-]
 
 [[package]]
 name = "base64"
@@ -175,16 +108,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bcder"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b593e5aeaf7992d388c08a9831c921cd703718064b3e50ba8e6d666d6cf86ca7"
-dependencies = [
- "bytes",
- "smallvec",
-]
 
 [[package]]
 name = "bitflags"
@@ -236,9 +159,6 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "camino"
@@ -250,20 +170,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "cascade-api"
-version = "0.1.0-beta4"
-source = "git+https://github.com/NLnetLabs/cascade?tag=v0.1.0-beta4#9faf1a14a9601c06d02966f3e2437b63df288a4a"
-dependencies = [
- "bytes",
- "camino",
- "domain",
- "serde",
-]
-
-[[package]]
 name = "cascade-cfg"
-version = "0.1.0-beta4"
-source = "git+https://github.com/NLnetLabs/cascade?tag=v0.1.0-beta4#9faf1a14a9601c06d02966f3e2437b63df288a4a"
+version = "0.1.0-beta6-dev"
+source = "git+https://github.com/NLnetLabs/cascade?branch=policy-file-subcrate#92ae3fec3cdda8e6830485d8e1d0d03c7ac09019"
 dependencies = [
  "camino",
  "clap",
@@ -285,49 +194,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cascade-zonedata"
-version = "0.1.0-beta4"
-source = "git+https://github.com/NLnetLabs/cascade?tag=v0.1.0-beta4#9faf1a14a9601c06d02966f3e2437b63df288a4a"
+name = "cascade-policy-file"
+version = "0.1.0-beta6-dev"
 dependencies = [
- "bytes",
- "domain",
-]
-
-[[package]]
-name = "cascaded"
-version = "0.1.0-beta4"
-source = "git+https://github.com/NLnetLabs/cascade?tag=v0.1.0-beta4#9faf1a14a9601c06d02966f3e2437b63df288a4a"
-dependencies = [
- "axum",
- "bytes",
  "camino",
- "cascade-api",
- "cascade-cfg",
- "cascade-zonedata",
- "clap",
- "crossbeam-utils",
- "daemonbase",
  "domain",
- "domain-kmip",
  "foldhash 0.2.0",
- "futures",
- "futures-util",
- "hostname",
  "jiff",
- "lazy_static",
- "prometheus-client",
- "rayon",
- "ring",
  "serde",
- "serde_json",
  "serde_with",
- "supports-color",
- "tempfile",
- "tokio",
  "toml 1.1.4+spec-1.1.0",
- "tracing",
- "tracing-subscriber",
- "url",
 ]
 
 [[package]]
@@ -474,25 +350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-queue"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,7 +387,6 @@ dependencies = [
  "serde",
  "syslog",
  "time",
- "tokio",
  "toml_edit",
 ]
 
@@ -651,50 +507,25 @@ dependencies = [
 [[package]]
 name = "domain"
 version = "0.12.2"
-source = "git+https://github.com/NLnetLabs/domain?branch=main#fa52d81acd61876f7a8171522a74d8a049f107d1"
+source = "git+https://github.com/NLnetLabs/domain?branch=main#4738f6779b965ffb46e59b15c335b903d9e1d9c4"
 dependencies = [
- "arc-swap",
  "bumpalo",
  "bytes",
  "constant_time_eq",
  "domain-macros",
- "futures-util",
  "hashbrown 0.17.1",
  "jiff",
- "libc",
- "log",
  "octseq",
- "openssl",
- "parking_lot",
  "rand 0.10.2",
  "ring",
- "rustversion",
- "secrecy",
  "serde",
- "siphasher",
  "smallvec",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "domain-kmip"
-version = "0.0.1"
-source = "git+https://github.com/NLnetLabs/domain-kmip.git?branch=main#632dfab6c191a2d191e7fc670e246d4e87da6bf7"
-dependencies = [
- "bcder",
- "domain",
- "kmip-protocol",
- "tracing",
- "url",
- "uuid",
 ]
 
 [[package]]
 name = "domain-macros"
 version = "0.12.2"
-source = "git+https://github.com/NLnetLabs/domain?branch=main#fa52d81acd61876f7a8171522a74d8a049f107d1"
+source = "git+https://github.com/NLnetLabs/domain?branch=main#4738f6779b965ffb46e59b15c335b903d9e1d9c4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -706,12 +537,6 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
-name = "dtoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "dyn-clone"
@@ -726,26 +551,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "enum-ordinalize"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
-dependencies = [
- "enum-ordinalize-derive",
-]
-
-[[package]]
-name = "enum-ordinalize-derive"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -786,12 +591,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
-
-[[package]]
 name = "file-owner"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,12 +617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,21 +627,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -866,21 +644,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
 ]
 
 [[package]]
@@ -928,17 +691,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
-name = "futures-macro"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,10 +708,8 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -998,25 +748,6 @@ dependencies = [
  "libc",
  "r-efi",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1102,87 +833,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-link",
-]
-
-[[package]]
-name = "http"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hyper"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "bytes",
- "http",
- "http-body",
- "hyper",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -1351,12 +1001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_ci"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,42 +1077,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kmip-protocol"
-version = "0.5.0"
-source = "git+https://github.com/NLnetLabs/kmip-protocol?branch=next#03cc2defe51ecbfc89621d92f80f30042bdc0178"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "enum-ordinalize",
- "hex",
- "kmip-ttlv",
- "log",
- "maybe-async",
- "r2d2",
- "rustc_version",
- "rustls",
- "rustls-pemfile",
- "serde",
- "serde_bytes",
- "serde_derive",
- "tracing",
- "webpki-roots",
-]
-
-[[package]]
-name = "kmip-ttlv"
-version = "0.4.0"
-source = "git+https://github.com/NLnetLabs/kmip-ttlv?branch=next#295572e07feb30293462267db2de1640ba1bfabe"
-dependencies = [
- "cfg-if",
- "hex",
- "maybe-async",
- "rustc_version",
- "serde",
- "tracing",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,23 +1148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "maybe-async"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,12 +1173,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,15 +1194,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1697,8 +1273,9 @@ version = "0.1.0-alpha1"
 dependencies = [
  "anyhow",
  "atoi",
+ "cascade-cfg",
  "cascade-hsm-bridge-cfg",
- "cascaded",
+ "cascade-policy-file",
  "domain",
  "file-owner",
  "fs-err",
@@ -1725,43 +1302,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking"
@@ -1911,29 +1451,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus-client"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca3d75b4566b9a29fe1ed623587fb058e826eb329a0be4b7c4da1ebb2d7a6ca"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot",
- "prometheus-client-derive-encode",
-]
-
-[[package]]
-name = "prometheus-client-derive-encode"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,17 +1474,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "r2d2"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
-dependencies = [
- "log",
- "parking_lot",
- "scheduled-thread-pool",
-]
 
 [[package]]
 name = "rand"
@@ -2015,26 +1521,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -2152,15 +1638,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2171,50 +1648,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
-dependencies = [
- "log",
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -2236,15 +1669,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc984f4f9ceb736a7bb755c3e3bd17dc56370af2600c9780dcc48c66453da34d"
 dependencies = [
  "regex",
-]
-
-[[package]]
-name = "scheduled-thread-pool"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
-dependencies = [
- "parking_lot",
 ]
 
 [[package]]
@@ -2278,21 +1702,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "secrecy"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,16 +1709,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2343,17 +1742,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2432,29 +1820,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
 
 [[package]]
 name = "signature"
@@ -2465,12 +1834,6 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
-
-[[package]]
-name = "siphasher"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2734,15 +2097,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "supports-color"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
-dependencies = [
- "is_ci",
-]
-
-[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2765,12 +2119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-
-[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2791,19 +2139,6 @@ dependencies = [
  "libc",
  "log",
  "time",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.3",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2834,15 +2169,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -2912,10 +2238,8 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -2937,20 +2261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -3032,33 +2342,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
-name = "tower"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3088,32 +2371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
-dependencies = [
- "nu-ansi-term",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -3171,7 +2428,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -3185,23 +2441,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
-dependencies = [
- "getrandom 0.4.3",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -3270,15 +2509,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,8 @@ rust-version = "1.88"
 [dependencies]
 anyhow            = "1.0.100"
 atoi              = "2.0.0"
-cascade-cfg       = { git = "https://github.com/NLnetLabs/cascade", branch = "policy-file-subcrate", package = "cascade-cfg" }
-#cascade-policy    = { git = "https://github.com/NLnetLabs/cascade", branch = "policy-file-subcrate", package = "cascade-policy-file" }
-cascade-policy    = { path = "../cascade-tmp/crates/policy-file", package = "cascade-policy-file" }
+cascade-cfg       = { git = "https://github.com/NLnetLabs/cascade", package = "cascade-cfg" }
+cascade-policy    = { git = "https://github.com/NLnetLabs/cascade", package = "cascade-policy-file" }
 domain            = { git = "https://github.com/NLnetLabs/domain", branch = "main" } # Use the same domain as cascade
 file-owner        = "0.1.2"
 fs-err            = "3.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ rust-version = "1.88"
 [dependencies]
 anyhow            = "1.0.100"
 atoi              = "2.0.0"
-cascaded          = { git = "https://github.com/NLnetLabs/cascade", tag = "v0.1.0-beta4" }
+cascade-cfg       = { git = "https://github.com/NLnetLabs/cascade", branch = "policy-file-subcrate", package = "cascade-cfg" }
+#cascade-policy    = { git = "https://github.com/NLnetLabs/cascade", branch = "policy-file-subcrate", package = "cascade-policy-file" }
+cascade-policy    = { path = "../cascade-tmp/crates/policy-file", package = "cascade-policy-file" }
 domain            = { git = "https://github.com/NLnetLabs/domain", branch = "main" } # Use the same domain as cascade
 file-owner        = "0.1.2"
 fs-err            = "3.2.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,17 +9,17 @@ use std::{
     net::{IpAddr, SocketAddr},
     path::{Path, PathBuf},
     str::FromStr,
-    time::Duration,
 };
 
 use anyhow::{anyhow, bail};
 use cascade_hsm_bridge_cfg::daemonbase::process::{GroupId, UserId};
-use cascaded::policy::{
-    AutoConfig, DsAlgorithm, NameserverCommsPolicy, OutboundPolicy, Policy, ReviewPolicy,
-    ServerPolicy, SignerDenialPolicy, SignerPolicy, SignerSerialPolicy,
+use cascade_policy::v1::{
+    CskManagementSpec, DsAlgorithmSpec, KeyGenerationParametersSpec, KeyManagerGenerationSpec,
+    KeyManagerRecordsSpec, KeyManagerSpec, KeyValiditySpec, KskManagementSpec, LoaderSpec,
+    NameserverCommsSpec, OutboundSpec, RecordSigningSpec, RolloverSpec, ServerSpec,
+    SignerDenialSpec, SignerSerialPolicySpec, SignerSpec, SimpleNameserverCommsSpec, TimeSpan,
+    ZskManagementSpec,
 };
-use cascaded::{config::file::Spec, policy::KeyParameters};
-use domain::base::Ttl;
 use quick_xml::DeError;
 use schema::xml::addns::{Adapter, Outbound};
 use schema::xml::conf::Configuration;
@@ -203,8 +203,8 @@ impl Migrator {
 
         println!("Loading {c_conf_toml_path}...");
         let toml = io.read_to_string(c_conf_toml_path)?;
-        let c_conf_spec: Spec = toml::from_str(&toml)?;
-        let mut c_conf = cascaded::config::Config::default();
+        let c_conf_spec: cascade_cfg::file::v1::Spec = toml::from_str(&toml)?;
+        let mut c_conf = cascade_cfg::Config::default();
         c_conf_spec.parse_into(&mut c_conf);
         let c_pol_dir = c_conf.policy_dir.clone();
 
@@ -478,7 +478,7 @@ impl Migrator {
         let mut o_addns_path_by_o_zone_name = BTreeMap::<String, String>::new();
 
         // Cascade policy name -> Cascade policy
-        let mut c_pol_by_c_pol_name = BTreeMap::<String, cascaded::policy::file::Spec>::new();
+        let mut c_pol_by_c_pol_name = BTreeMap::<String, cascade_policy::v1::Spec>::new();
 
         // ODS zone name -> ODS signed zone output path
         let _o_signed_zone_output_paths_by_zone_name = BTreeMap::<String, String>::new();
@@ -865,17 +865,9 @@ impl Migrator {
                 }
             }
 
-            // As policy saving cannot be told to use the simulated test
-            // filesystem, handle the test case separately doing the main
-            // things that actually policy saving does.
-            #[cfg(not(test))]
-            c_pol.save(out_path.as_str().into())?;
-            #[cfg(test)]
-            {
-                let toml = toml::to_string_pretty(&c_pol)?;
-                let mut file = io.create(out_path)?;
-                file.write_all(toml.as_bytes())?;
-            }
+            let toml = toml::to_string_pretty(&c_pol)?;
+            let mut file = io.create(out_path)?;
+            file.write_all(toml.as_bytes())?;
             c_pol_by_c_pol_name.insert(c_pol_name.to_string(), c_pol);
         }
 
@@ -1032,8 +1024,7 @@ impl Migrator {
                     // the key. Cascade can't do that so we need to know which
                     // repository it should be in. We get that from the zone
                     // policy.
-                    let cascaded::policy::file::Spec::V1(c_pol) =
-                        c_pol_by_c_pol_name.get(c_pol_name).unwrap();
+                    let c_pol = c_pol_by_c_pol_name.get(c_pol_name).unwrap();
                     let hsm_server_id =
                         c_pol.key_manager.generation.hsm_server_id.as_ref().unwrap();
 
@@ -1582,7 +1573,7 @@ struct GenerateReadmeConfig<'a> {
 }
 
 struct GenerateReadmeCascadeConfig<'a> {
-    conf: &'a cascaded::config::Config,
+    conf: &'a cascade_cfg::Config,
     conf_toml_path: &'a str,
 }
 
@@ -1642,25 +1633,26 @@ fn process_xml<'de, T: Deserialize<'de>>(xml: &'de str) -> Result<T, DeError> {
 }
 
 #[rustfmt::skip]
-pub fn eq_excluding_length(lhs: &KeyParameters, rhs: &KeyParameters) -> bool {
+pub fn eq_excluding_length(lhs: &cascade_policy::v1::KeyGenerationParametersSpec, rhs: &KeyGenerationParametersSpec) -> bool {
     matches!(
         (lhs, rhs),
-        (KeyParameters::RsaSha256(_),    KeyParameters::RsaSha256(_))    |
-        (KeyParameters::RsaSha512(_),    KeyParameters::RsaSha512(_))    |
-        (KeyParameters::EcdsaP256Sha256, KeyParameters::EcdsaP256Sha256) |
-        (KeyParameters::EcdsaP384Sha384, KeyParameters::EcdsaP384Sha384) |
-        (KeyParameters::Ed25519,         KeyParameters::Ed25519)         |
-        (KeyParameters::Ed448,           KeyParameters::Ed448)
+        (KeyGenerationParametersSpec::RsaSha256(_),    KeyGenerationParametersSpec::RsaSha256(_))    |
+        (KeyGenerationParametersSpec::RsaSha512(_),    KeyGenerationParametersSpec::RsaSha512(_))    |
+        (KeyGenerationParametersSpec::EcdsaP256Sha256, KeyGenerationParametersSpec::EcdsaP256Sha256) |
+        (KeyGenerationParametersSpec::EcdsaP384Sha384, KeyGenerationParametersSpec::EcdsaP384Sha384) |
+        (KeyGenerationParametersSpec::Ed25519,         KeyGenerationParametersSpec::Ed25519)         |
+        (KeyGenerationParametersSpec::Ed448,           KeyGenerationParametersSpec::Ed448)
     )
 }
 
-pub fn key_length(key: &KeyParameters) -> Option<usize> {
+pub fn key_length(key: &KeyGenerationParametersSpec) -> Option<u16> {
     match key {
-        KeyParameters::RsaSha256(len) | KeyParameters::RsaSha512(len) => Some(*len),
-        KeyParameters::EcdsaP256Sha256
-        | KeyParameters::EcdsaP384Sha384
-        | KeyParameters::Ed25519
-        | KeyParameters::Ed448 => None,
+        KeyGenerationParametersSpec::RsaSha256(len)
+        | KeyGenerationParametersSpec::RsaSha512(len) => Some(*len),
+        KeyGenerationParametersSpec::EcdsaP256Sha256
+        | KeyGenerationParametersSpec::EcdsaP384Sha384
+        | KeyGenerationParametersSpec::Ed25519
+        | KeyGenerationParametersSpec::Ed448 => None,
     }
 }
 
@@ -1672,7 +1664,7 @@ fn create_cascade_policy(
     kasp: &crate::schema::xml::kasp::Policy,
     output: Option<&Outbound>,
     hsm_server_id: Option<String>,
-) -> anyhow::Result<(cascaded::policy::file::Spec, bool, bool)> {
+) -> anyhow::Result<(cascade_policy::v1::Spec, bool, bool)> {
     // NOTE: OpenDNSSEC supports multiple keys per key type (KSK, ZSK, CSK)
     // per policy each having their own algorithm settings. Cascade only
     // supports one key specification per policy. Use the first key found.
@@ -1730,17 +1722,17 @@ fn create_cascade_policy(
             let port = remote.port.unwrap_or(53);
             let ip_addr = IpAddr::from_str(&remote.address)?;
             let addr = SocketAddr::new(ip_addr, port);
-            let comms_policy = NameserverCommsPolicy {
+            let comms_policy = NameserverCommsSpec::Simple(SimpleNameserverCommsSpec {
                 addr,
                 tsig_key_name: None, // TODO
-            };
+            });
             send_notify_to.push(comms_policy);
         }
     }
 
     let denial = match &kasp.denial.denial {
-        DenialEnum::nsec(_) => SignerDenialPolicy::NSec,
-        DenialEnum::nsec3(nsec3) => SignerDenialPolicy::NSec3 {
+        DenialEnum::nsec(_) => SignerDenialSpec::NSec,
+        DenialEnum::nsec3(nsec3) => SignerDenialSpec::NSec3 {
             opt_out: nsec3.opt_out.is_some(),
         },
     };
@@ -1758,103 +1750,118 @@ fn create_cascade_policy(
     // We'll enable Cascades' automatic algorithm rollover support as
     // OpenDNSSEC 2.x apparently has support for algorithm rollover.
     // See: https://www.mail-archive.com/opendnssec-announce@lists.opendnssec.org/msg00012.html
-    let auto_algorithm = AutoConfig::default();
+    let auto_algorithm = RolloverSpec::default();
 
     // Cascade doesn't yet support restricting XFR from secondaries.
     // Allow XFR from any secondary.
     let provide_xfr_to = vec![];
 
-    let policy = cascaded::policy::PolicyVersion {
-        name: kasp.name.clone().into_boxed_str(),
-        loader: cascaded::policy::LoaderPolicy {
-            review: ReviewPolicy::default(), // ODS doesn't have this concept
+    let record_signing_spec = RecordSigningSpec {
+        signature_inception_offset: TimeSpan::from_secs(parse_ods_ts(
+            &kasp.signatures.inception_offset,
+        )),
+        signature_lifetime: TimeSpan::from_secs(parse_ods_ts(
+            kasp.signatures
+                .validity
+                .keyset
+                .as_ref()
+                .unwrap_or(&kasp.signatures.validity.default),
+        )),
+        signature_remain_time: TimeSpan::from_secs(parse_ods_ts(&kasp.signatures.refresh)),
+    };
+
+    let policy = cascade_policy::v1::Spec {
+        loader: LoaderSpec {
+            review: None, // ODS doesn't have this concept
         },
-        key_manager: cascaded::policy::KeyManagerPolicy {
-            hsm_server_id,
-            use_csk,
-            algorithm: policy_algorithm.unwrap(),
-            ksk_validity: ksk.map(|k| parse_ods_ts(&k.lifetime)),
-            zsk_validity: zsk.map(|k| parse_ods_ts(&k.lifetime)),
-            csk_validity: csk.map(|k| parse_ods_ts(&k.lifetime)),
-            auto_ksk,
-            auto_zsk,
-            auto_csk,
-            auto_algorithm,
-            dnskey_inception_offset: parse_ods_ts(&kasp.signatures.inception_offset),
-            dnskey_signature_lifetime: parse_ods_ts(
-                kasp.signatures
-                    .validity
-                    .keyset
-                    .as_ref()
-                    .unwrap_or(&kasp.signatures.validity.default),
-            ),
-            dnskey_remain_time: parse_ods_ts(&kasp.signatures.refresh),
-            cds_inception_offset: parse_ods_ts(&kasp.signatures.inception_offset),
-            cds_signature_lifetime: parse_ods_ts(
-                kasp.signatures
-                    .validity
-                    .keyset
-                    .as_ref()
-                    .unwrap_or(&kasp.signatures.validity.default),
-            ),
-            cds_remain_time: parse_ods_ts(&kasp.signatures.refresh),
-            ds_algorithm: DsAlgorithm::default(),
-            default_ttl: Ttl::from_secs(parse_ods_ts(&kasp.keys.ttl)),
+        key_manager: KeyManagerSpec {
+            ksk: KskManagementSpec {
+                validity: match ksk {
+                    None => KeyValiditySpec::Forever,
+                    Some(k) => {
+                        KeyValiditySpec::Finite(TimeSpan::from_secs(parse_ods_ts(&k.lifetime)))
+                    }
+                },
+                rollover: auto_ksk,
+            },
+            zsk: ZskManagementSpec {
+                validity: match zsk {
+                    None => KeyValiditySpec::Forever,
+                    Some(k) => {
+                        KeyValiditySpec::Finite(TimeSpan::from_secs(parse_ods_ts(&k.lifetime)))
+                    }
+                },
+                rollover: auto_zsk,
+            },
+            csk: CskManagementSpec {
+                validity: match csk {
+                    None => KeyValiditySpec::Forever,
+                    Some(k) => {
+                        KeyValiditySpec::Finite(TimeSpan::from_secs(parse_ods_ts(&k.lifetime)))
+                    }
+                },
+                rollover: auto_csk,
+            },
+            algorithm: auto_algorithm,
+            ds_algorithm: DsAlgorithmSpec::default(),
             auto_remove: kasp.keys.purge.is_some(),
             auto_remove_delay: kasp
                 .keys
                 .purge
                 .as_ref()
-                .map(|ts| Duration::from_secs(parse_ods_ts(ts) as u64))
-                .unwrap_or_default(),
+                .map(|ts| TimeSpan::from_secs(parse_ods_ts(ts)))
+                .unwrap_or_else(|| TimeSpan::from_secs(0)),
+            records: KeyManagerRecordsSpec {
+                ttl: TimeSpan::from_secs(parse_ods_ts(&kasp.keys.ttl)),
+                dnskey: record_signing_spec.clone(),
+                cds: record_signing_spec,
+            },
+            generation: KeyManagerGenerationSpec {
+                hsm_server_id,
+                use_csk,
+                algorithm: policy_algorithm.unwrap(),
+            },
             publication_nameservers: Default::default(), // ODS doesn't have this concept
         },
-        signer: SignerPolicy {
+        signer: SignerSpec {
             serial_policy: match kasp.zone.soa.serial.serial {
-                SerialEnum::counter => SignerSerialPolicy::Counter,
-                SerialEnum::datecounter => SignerSerialPolicy::DateCounter,
-                SerialEnum::unixtime => SignerSerialPolicy::UnixTime,
-                SerialEnum::keep => SignerSerialPolicy::Keep,
+                SerialEnum::counter => SignerSerialPolicySpec::Counter,
+                SerialEnum::datecounter => SignerSerialPolicySpec::DateCounter,
+                SerialEnum::unixtime => SignerSerialPolicySpec::UnixTime,
+                SerialEnum::keep => SignerSerialPolicySpec::Keep,
             },
-            sig_inception_offset: parse_ods_ts(&kasp.signatures.inception_offset),
-            sig_validity_time: parse_ods_ts(&kasp.signatures.validity.default),
-            sig_remain_time: parse_ods_ts(&kasp.signatures.refresh),
+            signature_inception_offset: TimeSpan::from_secs(parse_ods_ts(
+                &kasp.signatures.inception_offset,
+            )),
+            signature_lifetime: TimeSpan::from_secs(parse_ods_ts(
+                &kasp.signatures.validity.default,
+            )),
+            signature_remain_time: TimeSpan::from_secs(parse_ods_ts(&kasp.signatures.refresh)),
             denial,
-            review: ReviewPolicy::default(), // ODS doesn't have this concept
-            signature_refresh_interval: 12 * 3600, // ODS doesn't have this concept, match the Cascade default
-            key_roll_time: 24 * 3600, // ODS doesn't have this concept, match the Cascade default
+            ..Default::default() // ODS doesn't have the other concepts in this struct
         },
-        server: ServerPolicy {
-            outbound: OutboundPolicy {
+        server: ServerSpec {
+            outbound: OutboundSpec {
                 provide_xfr_to,
                 send_notify_to,
+                ..Default::default()
             },
         },
     };
 
-    let policy = Policy {
-        latest: policy.into(),
-        mid_deletion: false,
-        zones: Default::default(),
-    };
-
-    Ok((
-        cascaded::policy::file::Spec::build(&policy),
-        key_length_upgraded,
-        extra_keys_ignored,
-    ))
+    Ok((policy, key_length_upgraded, extra_keys_ignored))
 }
 
-fn manual_or_automatic(manual_rollover: Option<()>) -> AutoConfig {
+fn manual_or_automatic(manual_rollover: Option<()>) -> RolloverSpec {
     if manual_rollover.is_some() {
-        AutoConfig {
-            start: false,
-            report: false,
-            expire: false,
-            done: false,
+        RolloverSpec {
+            auto_start: false,
+            auto_report: false,
+            auto_expire: false,
+            auto_done: false,
         }
     } else {
-        AutoConfig::default()
+        RolloverSpec::default()
     }
 }
 
@@ -1957,19 +1964,23 @@ fn atoi_with_rest<I: atoi::FromRadix10>(text: &[u8]) -> (&[u8], Option<I>) {
     }
 }
 
-fn alg_to_key_parameters(key: Key) -> cascaded::policy::KeyParameters {
+fn alg_to_key_parameters(key: Key) -> cascade_policy::v1::KeyGenerationParametersSpec {
     let algorithm = match key {
         Key::Ksk(k) => &k.algorithm,
         Key::Zsk(k) => &k.algorithm,
         Key::Csk(k) => &k.algorithm,
     };
     match algorithm.value.as_str() {
-        "8" => cascaded::policy::KeyParameters::RsaSha256(algorithm.length.parse().unwrap()),
-        "10" => cascaded::policy::KeyParameters::RsaSha512(algorithm.length.parse().unwrap()),
-        "13" => cascaded::policy::KeyParameters::EcdsaP256Sha256,
-        "14" => cascaded::policy::KeyParameters::EcdsaP256Sha256,
-        "15" => cascaded::policy::KeyParameters::Ed25519,
-        "16" => cascaded::policy::KeyParameters::Ed448,
+        "8" => cascade_policy::v1::KeyGenerationParametersSpec::RsaSha256(
+            algorithm.length.parse().unwrap(),
+        ),
+        "10" => cascade_policy::v1::KeyGenerationParametersSpec::RsaSha512(
+            algorithm.length.parse().unwrap(),
+        ),
+        "13" => cascade_policy::v1::KeyGenerationParametersSpec::EcdsaP256Sha256,
+        "14" => cascade_policy::v1::KeyGenerationParametersSpec::EcdsaP256Sha256,
+        "15" => cascade_policy::v1::KeyGenerationParametersSpec::Ed25519,
+        "16" => cascade_policy::v1::KeyGenerationParametersSpec::Ed448,
         alg => panic!("Unsupported algorithm number {alg}"),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1813,7 +1813,7 @@ fn create_cascade_policy(
                 .unwrap_or_else(|| TimeSpan::from_secs(0)),
             records: KeyManagerRecordsSpec {
                 ttl: TimeSpan::from_secs(parse_ods_ts(&kasp.keys.ttl)),
-                dnskey: record_signing_spec.clone(),
+                dnskey: record_signing_spec,
                 cds: record_signing_spec,
             },
             generation: KeyManagerGenerationSpec {


### PR DESCRIPTION
See https://github.com/NLnetLabs/cascade/pull/935.